### PR TITLE
Add markdown transcript export (?format=md) for room recordings

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,6 +6,13 @@ import multer from "multer";
 import { openai, analyzeConversation, chatCompletion, isValidModel, getAllValidModels, getProvider } from "./ai-provider";
 import WebSocket from "ws";
 import { activityPubRouter } from "./activitypub/routes";
+import {
+  parseTranscriptFormat,
+  transcriptFilename,
+  buildTranscriptJson,
+  renderTranscriptText,
+  renderTranscriptMarkdown,
+} from "./transcript";
 
 const PERSONAPLEX_HOST = "cjuzwdji4o9zi2-8998.proxy.runpod.net";
 
@@ -215,33 +222,25 @@ export async function registerRoutes(
       if (!room) return res.status(404).json({ error: "Room not found" });
 
       const entries = await storage.getEntriesByRoom(roomId);
-      const format = (req.query.format as string) || "txt";
+      const format = parseTranscriptFormat(req.query.format);
+      const filename = transcriptFilename(room, format);
 
       if (format === "json") {
         res.setHeader("Content-Type", "application/json");
-        res.setHeader("Content-Disposition", `attachment; filename="transcript-${room.name}-${new Date().toISOString().slice(0, 10)}.json"`);
-        return res.json({
-          room: room.name,
-          exportedAt: new Date().toISOString(),
-          entryCount: entries.length,
-          entries: entries.map(e => ({
-            speaker: e.speaker,
-            content: e.content,
-            timestamp: e.timestamp,
-          })),
-        });
+        res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+        return res.json(buildTranscriptJson(room, entries));
+      }
+
+      if (format === "md") {
+        res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+        res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+        return res.send(renderTranscriptMarkdown(room, entries));
       }
 
       // Default: plain text
-      const lines = entries.map(e => {
-        const time = e.timestamp ? new Date(e.timestamp).toLocaleTimeString() : "";
-        return `[${time}] ${e.speaker}: ${e.content}`;
-      });
-      const text = `Transcript: ${room.name}\nExported: ${new Date().toISOString()}\nEntries: ${entries.length}\n${"—".repeat(40)}\n\n${lines.join("\n")}`;
-
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
-      res.setHeader("Content-Disposition", `attachment; filename="transcript-${room.name}-${new Date().toISOString().slice(0, 10)}.txt"`);
-      return res.send(text);
+      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+      return res.send(renderTranscriptText(room, entries));
     } catch (error) {
       console.error("Error exporting transcript:", error);
       res.status(500).json({ error: "Failed to export transcript" });

--- a/server/transcript.test.ts
+++ b/server/transcript.test.ts
@@ -1,0 +1,88 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import {
+  parseTranscriptFormat,
+  transcriptFilename,
+  buildTranscriptJson,
+  renderTranscriptText,
+  renderTranscriptMarkdown,
+  type TranscriptEntry,
+} from "./transcript";
+
+const NOW = new Date("2026-02-24T19:30:00.000Z");
+const room = { name: "Room 1" };
+const entries: TranscriptEntry[] = [
+  { speaker: "Vascocomp", content: "I wish I had a recording of this conversation.", timestamp: "2026-02-24T19:16:32.841Z" },
+  { speaker: "Iwakura", content: "Then let the record itself become the surprise.", timestamp: "2026-02-24T19:17:10.000Z" },
+];
+
+describe("parseTranscriptFormat", () => {
+  test("recognizes json and md, defaults everything else to txt", () => {
+    assert.strictEqual(parseTranscriptFormat("json"), "json");
+    assert.strictEqual(parseTranscriptFormat("md"), "md");
+    assert.strictEqual(parseTranscriptFormat("txt"), "txt");
+    assert.strictEqual(parseTranscriptFormat("markdown"), "txt");
+    assert.strictEqual(parseTranscriptFormat(undefined), "txt");
+  });
+});
+
+describe("transcriptFilename", () => {
+  test("uses the correct extension per format and the YYYY-MM-DD date", () => {
+    assert.strictEqual(transcriptFilename(room, "md", NOW), "transcript-Room 1-2026-02-24.md");
+    assert.strictEqual(transcriptFilename(room, "json", NOW), "transcript-Room 1-2026-02-24.json");
+    assert.strictEqual(transcriptFilename(room, "txt", NOW), "transcript-Room 1-2026-02-24.txt");
+  });
+});
+
+describe("buildTranscriptJson", () => {
+  test("preserves the original payload shape", () => {
+    const payload = buildTranscriptJson(room, entries, NOW);
+    assert.strictEqual(payload.room, "Room 1");
+    assert.strictEqual(payload.exportedAt, "2026-02-24T19:30:00.000Z");
+    assert.strictEqual(payload.entryCount, 2);
+    assert.deepStrictEqual(payload.entries[0], {
+      speaker: "Vascocomp",
+      content: "I wish I had a recording of this conversation.",
+      timestamp: "2026-02-24T19:16:32.841Z",
+    });
+  });
+});
+
+describe("renderTranscriptText", () => {
+  test("keeps the original plain-text structure", () => {
+    const text = renderTranscriptText(room, entries, NOW);
+    assert.ok(text.startsWith("Transcript: Room 1\n"));
+    assert.ok(text.includes("Exported: 2026-02-24T19:30:00.000Z"));
+    assert.ok(text.includes("Entries: 2"));
+    assert.ok(text.includes("Vascocomp: I wish I had a recording of this conversation."));
+    assert.ok(text.includes("Iwakura: Then let the record itself become the surprise."));
+  });
+});
+
+describe("renderTranscriptMarkdown", () => {
+  test("renders a readable markdown recording", () => {
+    const md = renderTranscriptMarkdown(room, entries, NOW);
+    assert.ok(md.startsWith("# Room 1 — Transcript\n"));
+    assert.ok(md.includes("> Exported 2026-02-24T19:30:00.000Z · 2 entries · CIMC Spirits"));
+    assert.ok(md.includes("**Vascocomp**"));
+    assert.ok(md.includes("I wish I had a recording of this conversation."));
+    assert.ok(md.includes("**Iwakura**"));
+    assert.ok(md.endsWith("\n"));
+  });
+
+  test("pluralizes a single entry as 'entry'", () => {
+    const md = renderTranscriptMarkdown(room, [entries[0]], NOW);
+    assert.ok(md.includes("· 1 entry ·"));
+  });
+
+  test("handles an empty room gracefully", () => {
+    const md = renderTranscriptMarkdown(room, [], NOW);
+    assert.ok(md.includes("_No entries yet._"));
+  });
+
+  test("omits the time marker when a timestamp is missing", () => {
+    const md = renderTranscriptMarkdown(room, [{ speaker: "Anon", content: "No clock here.", timestamp: null }], NOW);
+    assert.ok(md.includes("**Anon**\n\nNo clock here."));
+    assert.ok(!md.includes("**Anon** · *"));
+  });
+});

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -1,0 +1,83 @@
+// Pure transcript formatting helpers for the room export endpoint.
+//
+// Extracted from routes.ts so the txt / json / markdown rendering can be unit
+// tested without standing up Express, the database, or websockets. The route
+// stays a thin adapter that sets headers and delegates the body here.
+
+export type TranscriptFormat = "txt" | "json" | "md";
+
+export interface TranscriptRoom {
+  name: string;
+}
+
+export interface TranscriptEntry {
+  speaker: string;
+  content: string;
+  timestamp?: Date | string | number | null;
+}
+
+export interface TranscriptJson {
+  room: string;
+  exportedAt: string;
+  entryCount: number;
+  entries: Array<{ speaker: string; content: string; timestamp: TranscriptEntry["timestamp"] }>;
+}
+
+/** Normalize the requested ?format= value; anything unknown falls back to txt. */
+export function parseTranscriptFormat(raw: unknown): TranscriptFormat {
+  return raw === "json" || raw === "md" ? raw : "txt";
+}
+
+/** Suggested download filename, e.g. transcript-Room 1-2026-02-24.md */
+export function transcriptFilename(room: TranscriptRoom, format: TranscriptFormat, now: Date = new Date()): string {
+  const ext = format === "json" ? "json" : format === "md" ? "md" : "txt";
+  return `transcript-${room.name}-${now.toISOString().slice(0, 10)}.${ext}`;
+}
+
+function formatTime(timestamp: TranscriptEntry["timestamp"]): string {
+  return timestamp ? new Date(timestamp).toLocaleTimeString() : "";
+}
+
+/** Structured JSON payload (unchanged from the original inline implementation). */
+export function buildTranscriptJson(room: TranscriptRoom, entries: TranscriptEntry[], now: Date = new Date()): TranscriptJson {
+  return {
+    room: room.name,
+    exportedAt: now.toISOString(),
+    entryCount: entries.length,
+    entries: entries.map((e) => ({
+      speaker: e.speaker,
+      content: e.content,
+      timestamp: e.timestamp,
+    })),
+  };
+}
+
+/** Plain-text transcript (unchanged from the original inline implementation). */
+export function renderTranscriptText(room: TranscriptRoom, entries: TranscriptEntry[], now: Date = new Date()): string {
+  const lines = entries.map((e) => `[${formatTime(e.timestamp)}] ${e.speaker}: ${e.content}`);
+  return `Transcript: ${room.name}\nExported: ${now.toISOString()}\nEntries: ${entries.length}\n${"—".repeat(40)}\n\n${lines.join("\n")}`;
+}
+
+/** Markdown transcript: a readable "recording" of the conversation (closes #49). */
+export function renderTranscriptMarkdown(room: TranscriptRoom, entries: TranscriptEntry[], now: Date = new Date()): string {
+  const header = [
+    `# ${room.name} — Transcript`,
+    "",
+    `> Exported ${now.toISOString()} · ${entries.length} ${entries.length === 1 ? "entry" : "entries"} · CIMC Spirits`,
+    "",
+    "---",
+    "",
+  ].join("\n");
+
+  if (entries.length === 0) {
+    return `${header}_No entries yet._\n`;
+  }
+
+  const blocks = entries.map((e) => {
+    const time = formatTime(e.timestamp);
+    const heading = time ? `**${e.speaker}** · *${time}*` : `**${e.speaker}**`;
+    return `${heading}\n\n${e.content}`;
+  });
+
+  return `${header}${blocks.join("\n\n")}\n`;
+}


### PR DESCRIPTION
Closes #49.

The room export endpoint already supports `txt` and `json`. This adds a third format — a markdown *recording* of a room's conversation — so "I wish I had a recording of this conversation" has a readable, shareable artifact.

- `GET /api/rooms/:roomId/export?format=md` → `text/markdown` download
- The txt / json / md rendering is extracted into pure helpers in `server/transcript.ts`; the route is now a thin adapter. **txt and json output are unchanged.**
- `server/transcript.test.ts` (node:test) covers markdown rendering, the empty-room and missing-timestamp edge cases, format parsing, filename extensions, and txt/json regression. `npm test` → 8 passing.

Follow-up (not in this PR): a download control in the room UI exposing the three formats.
